### PR TITLE
double // in u24  Preview call

### DIFF
--- a/featurescape/featurescape.js
+++ b/featurescape/featurescape.js
@@ -297,7 +297,7 @@ function plot(x) { // when ready to do it
     fscapeData.parmNum = parmNum;
 
     featurecrossTD.innerHTML = "<label>Click to choose a different cancer type &amp; tissue slide image:&nbsp;"
-        + '<input type="button" class="btn btn-secondary" onclick="window.open(\''+location.href.slice(0,location.href.indexOf('?'))+'\/u24Preview.html#' + findhost + ':' + findport + '\')" name="btnSelect" id="btnSelect" value="Go!" />'
+        + '<input type="button" class="btn btn-secondary" onclick="window.open(\''+location.href.slice(0,location.href.indexOf('?'))+'u24Preview.html#' + findhost + ':' + findport + '\')" name="btnSelect" id="btnSelect" value="Go!" />'
         + "</label><br><br>" + clust2html(cl);
 
     setTimeout(function () {


### PR DESCRIPTION
In response to issue https://github.com/SBU-BMI/FeatureScapeApps/issues/1:

<i>There is an error in the FeatureScapeApps URL linked from quip1.bmi.stonybrook.edu.

Clicking on the “Go!” button on the FeatureScape page will get the following URL:

http://sbu-bmi.github.io/FeatureScapeApps/featurescape//u24Preview.html#http://quip1.uhmc.sunysb.edu:3000

The double “//“ before u24Preview.html causes the URL to fall to load data.</i>